### PR TITLE
Issue #19 , #20 , #21, #25 has been fixed

### DIFF
--- a/features/admin_office/functionalities/src/commonMain/kotlin/com/just/cse/digital_diary/features/admin_office/components/offices_and_sub_offices/OfficesAndSubOffices.kt
+++ b/features/admin_office/functionalities/src/commonMain/kotlin/com/just/cse/digital_diary/features/admin_office/components/offices_and_sub_offices/OfficesAndSubOffices.kt
@@ -31,7 +31,7 @@ fun OfficesAndSubOffices(
     officeRepository: AdminOfficeListRepository,
     subOfficeRepository: AdminSubOfficeListRepository,
     onExitRequest: () -> Unit,
-    backHandler: @Composable (onBackButtonPress: () -> Unit) -> Unit,
+    backHandler: @Composable (onBackButtonPress: () -> Boolean) -> Unit,
 ) {
 
     val scope = rememberCoroutineScope()
@@ -70,7 +70,11 @@ fun OfficesAndSubOffices(
     }
     backHandler {
         if (subOfficeState != null)
-            viewModel.dismissSubOfficesDestination()
+        { viewModel.dismissSubOfficesDestination()
+            true
+        }
+        else
+            false
     }
     TwoPaneLayout(
         modifier = Modifier,

--- a/features/admin_office/navgraph/src/androidMain/kotlin/com/just/cse/digital_diary/features/admin_office/destination/AdminOfficeFeatureNavGraph.kt
+++ b/features/admin_office/navgraph/src/androidMain/kotlin/com/just/cse/digital_diary/features/admin_office/destination/AdminOfficeFeatureNavGraph.kt
@@ -16,7 +16,7 @@ object AdminOfficeFeatureNavGraph {
     private const val OFFICERS_SCREEN = "OfficersListScreen"
 
     @Composable
-    fun Graph(navController: NavHostController= rememberNavController(),onEvent:(AdminEvent)->Unit) {
+    fun Graph(navController: NavHostController= rememberNavController(),onEvent:(AdminEvent)->Unit,onBackPress:()->Unit) {
         NavHost(
             modifier = Modifier,
             navController = navController,
@@ -27,8 +27,11 @@ object AdminOfficeFeatureNavGraph {
                     onEmployeeListRequest = { subOffice ->
                         navController.navigate(OFFICERS_SCREEN)
                     },
-                    onBackButtonPress = {onBackPress ->
-                        BackHandler(onBack = onBackPress)
+                    onBackButtonPress = {callback ->
+                        BackHandler(onBack = {
+                           val isConsumed= callback()
+                            if (!isConsumed)onBackPress()
+                        })
 
                     },
                     onExitRequest = {

--- a/features/admin_office/navgraph/src/commonMain/kotlin/com/just/cse/digital_diary/features/admin_office/destination/screens/AdminOfficeAndSubOfficeRoute.kt
+++ b/features/admin_office/navgraph/src/commonMain/kotlin/com/just/cse/digital_diary/features/admin_office/destination/screens/AdminOfficeAndSubOfficeRoute.kt
@@ -8,7 +8,7 @@ import com.just.cse.digitaldiary.twozerotwothree.core.di.admin_offices.AdminOffi
 fun AdminOfficeAndSubOfficeRoute(
     onEmployeeListRequest: (String) -> Unit,
     onExitRequest: () -> Unit={},
-    onBackButtonPress:@Composable (onBackButtonPress: () -> Unit)->Unit={},
+    onBackButtonPress:@Composable (onBackButtonPress: () -> Boolean)->Unit={},
 ) {
     OfficesAndSubOffices(
         onEmployeeListRequest =onEmployeeListRequest,

--- a/features/faculty/functionalities/src/commonMain/kotlin/com/just/cse/digital_diary/features/faculty/components/functionalities/faculty_list/FacultyAndDepartmentList.kt
+++ b/features/faculty/functionalities/src/commonMain/kotlin/com/just/cse/digital_diary/features/faculty/components/functionalities/faculty_list/FacultyAndDepartmentList.kt
@@ -28,7 +28,7 @@ fun FacultyAndDepartmentList(
     departmentListRepository: DepartmentListRepository,
     onExitRequest:()->Unit,
     onEmployeeListRequest: (String) -> Unit = {},
-    backHandler: @Composable (onBackButtonPress: () -> Unit) -> Unit,
+    backHandler: @Composable (onBackButtonPress: () -> Boolean) -> Unit,
 ) {
     val viewModel = remember {
         FacultiesScreenViewModel(
@@ -62,7 +62,17 @@ fun FacultyAndDepartmentList(
     val showDepartmentList=departmentListState!=null
     backHandler {
         if (showDepartmentList)
-        viewModel.clearFacultySelection()
+        {
+            viewModel.clearFacultySelection()
+            true
+        //consuming the back event to dismiss department list
+        }
+        else{
+            //since department list closed,so only faculty list is opened
+            //user click on the back button,so we don't need to consume this  back press
+            false
+        }
+
     }
         TwoPaneLayout(
             showProgressBar = viewModel.uiState.collectAsState().value.isLoading,

--- a/features/faculty/navgraph/src/androidMain/kotlin/com/just/cse/digital_diary/features/faculty/destination/FacultyFeatureNavGraph.kt
+++ b/features/faculty/navgraph/src/androidMain/kotlin/com/just/cse/digital_diary/features/faculty/destination/FacultyFeatureNavGraph.kt
@@ -11,7 +11,6 @@ import com.just.cse.digital_diary.features.faculty.components.event.FacultyEvent
 import com.just.cse.digital_diary.features.faculty.destination.event.FacultyFeatureEvent
 import com.just.cse.digital_diary.features.faculty.destination.screens.FacultiesScreen
 import com.just.cse.digital_diary.features.faculty.destination.screens.TeachersScreen
-import com.just.cse.digital_diary.two_zero_two_three.architecture_layers.ui.teachers.event.TeacherListEvent
 
 object FacultyFeatureNavGraph {
     private const val FACULTY_SCREEN = "FacultyListScreen"
@@ -20,6 +19,7 @@ object FacultyFeatureNavGraph {
     @Composable
     fun Graph(
         navController: NavHostController = rememberNavController(),
+        onBackPressed: () -> Unit,
         onEvent: (FacultyFeatureEvent) -> Unit
     ) {
         NavHost(
@@ -27,13 +27,24 @@ object FacultyFeatureNavGraph {
             navController = navController,
             startDestination = FACULTY_SCREEN
         ) {
+
             composable(route = FACULTY_SCREEN) {
                 FacultiesScreen(
                     onTeacherListRequest = {
                         navController.navigate(TEACHERS_SCREEN)
                     },
                     backHandler = { onBackPress ->
-                        BackHandler(onBack = onBackPress)
+                        //overriding backhander will prevent it parent to notify that back button is
+                        //pressed as a result the parent nav controller may not notify that back button is pressed
+                        //as a result the parent nav controller may unable to pop destination automatically
+                        BackHandler(
+                            onBack = {
+                                val isConsumed = onBackPress()
+                                if (!isConsumed) {
+                                   onBackPressed()
+                                }
+                            },
+                        )
                     },
                     onExitRequest = {
                         onEvent(FacultyFeatureEvent.ExitRequest)

--- a/features/faculty/navgraph/src/commonMain/kotlin/com/just/cse/digital_diary/features/faculty/destination/screens/FacultiesScreen.kt
+++ b/features/faculty/navgraph/src/commonMain/kotlin/com/just/cse/digital_diary/features/faculty/destination/screens/FacultiesScreen.kt
@@ -7,12 +7,17 @@ import com.just.cse.digitaldiary.twozerotwothree.core.di.faculty.FacultyComponen
 /**
  * @param backHandler is to override the back button press functionality
  * used as composable so that composable and non composable both can be passed
+ * In case of android if we use BackHandler{} then back  event is not propagate to it parent
+ * composable as a result the parent nav controller will not receive the back button event so it will
+ * not pop the destination on back press,that is why,we have to explicitly notify the parent that
+ * the back event is consumed or not by return a [Boolean] from the [backHandler] onBackButtonPress lambda
+ *
  */
 @Composable
  fun FacultiesScreen(
     onTeacherListRequest: (String) -> Unit = {},
     onExitRequest:()->Unit,
-    backHandler: @Composable (onBackButtonPress: () -> Unit) -> Unit,
+    backHandler: @Composable (onBackButtonPress: () -> Boolean) -> Unit,
 ) {
     FacultyAndDepartmentList(
         modifier = Modifier,

--- a/features/navigation/src/androidMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/root_home/navigation/AndroidRootNavigation.kt
+++ b/features/navigation/src/androidMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/root_home/navigation/AndroidRootNavigation.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.just.cse.digital_diary.two_zero_two_three.features.others.destination.graph.OtherFeatureNavGraph
 import com.just.cse.digital_diary.two_zero_two_three.root_home.AppEvent
@@ -20,13 +22,13 @@ fun AndroidRootNavigation(
     onEvent: (AppEvent) -> Unit,
 ) {
     val navHostController = rememberNavController()
-
-
     var notSignedIn by remember { mutableStateOf(false) }
     val onLoginSuccess: (String, String) -> Unit = { _, _ ->
         notSignedIn = false
         navHostController.popBackStack()
-
+    }
+    val pop:()->Unit={
+        navHostController.popBackStack()
     }
     val onLogOutRequest: () -> Unit = {
         navHostController.navigate(GraphRoutes.AUTH)
@@ -57,19 +59,23 @@ fun AndroidRootNavigation(
                     }
 
                     TopMostDestination.FacultyList -> {
-                        navHostController.navigate(GraphRoutes.FACULTY_FEATURE)
+                        navigateAsTopMostDestination(GraphRoutes.FACULTY_FEATURE,navHostController)
+                       // navHostController.navigate()
                     }
 
                     TopMostDestination.AdminOffice -> {
-                        navHostController.navigate(GraphRoutes.ADMIN_OFFICE_FEATURE)
+                        navigateAsTopMostDestination(GraphRoutes.ADMIN_OFFICE_FEATURE,navHostController)
+                      //  navHostController.navigate(GraphRoutes.ADMIN_OFFICE_FEATURE)
                     }
 
                     TopMostDestination.Search -> {
-                        navHostController.navigate(GraphRoutes.SEARCH)
+                        navigateAsTopMostDestination(GraphRoutes.SEARCH,navHostController)
+                       // navHostController.navigate(GraphRoutes.SEARCH)
                     }
 
                     TopMostDestination.NoteList -> {
-                        navHostController.navigate(GraphRoutes.NOTES_FEATURE)
+                        navigateAsTopMostDestination(GraphRoutes.NOTES_FEATURE,navHostController)
+                        //navHostController.navigate(GraphRoutes.NOTES_FEATURE)
                     }
 
                     TopMostDestination.ExploreJust -> {
@@ -84,7 +90,8 @@ fun AndroidRootNavigation(
                     onEvent = onEvent,
                     openDrawerRequest = handler::openDrawer,
                     navController = navHostController,
-                    onLoginSuccess = onLoginSuccess
+                    onLoginSuccess = onLoginSuccess,
+                    onBackPressed = pop
                 )
             }
         )
@@ -92,4 +99,16 @@ fun AndroidRootNavigation(
     }
 
 
+}
+private fun navigateAsTopMostDestination(
+    destination: String,
+    navController: NavHostController
+) {
+    navController.navigate(destination) {
+        popUpTo(navController.graph.findStartDestination().id) {
+            saveState = true
+        }
+        launchSingleTop = true
+        restoreState = true
+    }
 }

--- a/features/navigation/src/androidMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/root_home/navigation/RootNavGraph.kt
+++ b/features/navigation/src/androidMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/root_home/navigation/RootNavGraph.kt
@@ -1,6 +1,7 @@
 package com.just.cse.digital_diary.two_zero_two_three.root_home.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -21,13 +22,20 @@ fun RootNavGraph(
     modifier: Modifier = Modifier,
     onEvent: (AppEvent) -> Unit,
     openDrawerRequest: () -> Unit,
-    onLoginSuccess:(String,String)->Unit,
+    onBackPressed: () -> Unit,
+    onLoginSuccess: (String, String) -> Unit,
     navController: NavHostController,
 ) {
+    LaunchedEffect(Unit) {
+        navController.currentBackStack.collect {
+            println("RootNavGraph:Stack: ${it.map { it.destination.route }}")
+        }
+    }
+
     NavHost(
         modifier = modifier,
         navController = navController,
-        startDestination = GraphRoutes.FACULTY_FEATURE
+        startDestination = GraphRoutes.OTHER_FEATURE
     ) {
         OtherFeatureNavGraph.graph(navGraphBuilder = this, onExitRequest = openDrawerRequest)
         composable(GraphRoutes.ADMIN_OFFICE_FEATURE) {
@@ -36,7 +44,8 @@ fun RootNavGraph(
                     if (event is AdminEvent.ExitRequest)
                         openDrawerRequest()
                     toAppEvent(event)?.let(onEvent)
-                }
+                },
+                onBackPress = onBackPressed
             )
         }
         composable(GraphRoutes.FACULTY_FEATURE) {
@@ -45,12 +54,14 @@ fun RootNavGraph(
                     if (event is FacultyFeatureEvent.ExitRequest)
                         openDrawerRequest()
                     toAppEvent(event)?.let(onEvent)
-                }
+                },
+                onBackPressed = onBackPressed
             )
         }
         composable(GraphRoutes.NOTES_FEATURE) {
             NotesFeatureNavGraph.Graph(
-                onExitRequest = openDrawerRequest
+                onExitRequest = openDrawerRequest,
+                onBackPressed = onBackPressed
             )
         }
         composable(GraphRoutes.SEARCH) {
@@ -63,7 +74,7 @@ fun RootNavGraph(
             )
         }
         composable(GraphRoutes.AUTH) {
-            AuthenticationNavGraph.Graph(onLoginSuccess=onLoginSuccess)
+            AuthenticationNavGraph.Graph(onLoginSuccess = onLoginSuccess)
         }
 
     }

--- a/features/notes/functionalities/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/sharing_document/destination/functionalities/list_and_details/ListAndDetails.kt
+++ b/features/notes/functionalities/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/sharing_document/destination/functionalities/list_and_details/ListAndDetails.kt
@@ -23,13 +23,16 @@ fun NotesAndDetailsRoute(
     selectedNoteId: String?,
     onNoteDetailsCloseRequest: () -> Unit,
     onDetailsRequest: (String) -> Unit,
-    onExitRequest:()->Unit,
-    backButtonHandler:@Composable (onBackButtonPress: () -> Unit)->Unit,
+    onExitRequest: () -> Unit,
+    backButtonHandler: @Composable (onBackButtonPress: () -> Boolean) -> Unit,
 ) {
-    val showDetails=selectedNoteId!= null
-    backButtonHandler{
-        if (showDetails)
-        onNoteDetailsCloseRequest()
+    val showDetails = selectedNoteId != null
+    backButtonHandler {
+        if (showDetails) {
+            onNoteDetailsCloseRequest()
+            true
+        } else
+            false
     }
     TwoPaneLayout(
         modifier = Modifier,
@@ -45,7 +48,7 @@ fun NotesAndDetailsRoute(
             NoteDetails(modifier = Modifier, id = "1")
         },
         alignment = Alignment.TopStart,
-        showTopOrRightPane =showDetails
+        showTopOrRightPane = showDetails
     )
 
 

--- a/features/notes/navgraph/src/androidMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/notes/navgraph/graph/NotesFeatureNavGraph.kt
+++ b/features/notes/navgraph/src/androidMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/notes/navgraph/graph/NotesFeatureNavGraph.kt
@@ -24,6 +24,7 @@ object NotesFeatureNavGraph {
     @Composable
     fun Graph(
         navController: NavHostController = rememberNavController(),
+        onBackPressed:()->Unit,
         onExitRequest:()->Unit,
     ) {
         var selectedNoteId: String? by remember { mutableStateOf(null) }
@@ -47,7 +48,12 @@ object NotesFeatureNavGraph {
                         },
                         selectedNoteId = selectedNoteId,
                         backButtonHandler = { callback ->
-                            BackHandler(onBack = callback)
+                            BackHandler(onBack = {
+                                val isConsumed=callback()
+                                if (!isConsumed){
+                                    onBackPressed()
+                                }
+                            })
                         },
                         onExitRequest = onExitRequest
                     )

--- a/features/others/navgraph/src/androidMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/features/others/destination/graph/OtherFeatureNavGraph.kt
+++ b/features/others/navgraph/src/androidMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/features/others/destination/graph/OtherFeatureNavGraph.kt
@@ -27,6 +27,9 @@ object OtherFeatureNavGraph {
     private const val EVENT_GALLERY_SCREEN = "EventGallery"
     private const val MESSAGE_FROM_VC_SCREEN = "MessageFromVC"
     private val showNavigationIcon = MutableStateFlow(true)
+    /**
+    Useful for nav rail
+     */
     fun enableBackNavigation() {
         showNavigationIcon.update { true }
     }

--- a/layers/ui/other_info/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/architecture_layers/other_info/components/home/HomeDestination.kt
+++ b/layers/ui/other_info/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/architecture_layers/other_info/components/home/HomeDestination.kt
@@ -20,7 +20,7 @@ fun HomeDestination(
             .padding(start = 16.dp)
             .fillMaxSize()
     ) {
-
+        Text("Welcome  to home")
 
     }
 


### PR DESCRIPTION
Issues #19, #20, and #25 occurred because the BackHandler composable was consuming the back event, preventing it from propagating up to the parent composable. As a result, the parent nav graph's NavController was not notified about the back press, which was the root cause of the bug. I have addressed this issue by notifying the RootNavGraph when the back button is pressed, especially when the back event is not consumed by the child destination.

There may be a more effective solution to resolve this bug. I will consider refactoring it later; currently, I don't have any alternative solution in mind