### PR TITLE
Issue #27 has been successfully resolved. 

### DIFF
--- a/features/navigation/src/androidMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/root_home/navigation/AndroidRootNavigation.kt
+++ b/features/navigation/src/androidMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/root_home/navigation/AndroidRootNavigation.kt
@@ -1,6 +1,7 @@
 package com.just.cse.digital_diary.two_zero_two_three.root_home.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -11,7 +12,7 @@ import androidx.navigation.compose.rememberNavController
 import com.just.cse.digital_diary.two_zero_two_three.features.others.destination.graph.OtherFeatureNavGraph
 import com.just.cse.digital_diary.two_zero_two_three.root_home.AppEvent
 import com.just.cse.digital_diary.two_zero_two_three.root_home.modal_drawer.ModalDrawerHandler
-import com.just.cse.digital_diary.two_zero_two_three.root_home.modal_drawer.RootModuleDrawer
+import com.just.cse.digital_diary.two_zero_two_three.root_home.modal_drawer.RootModuleDrawerAnimationLess
 import com.just.cse.digital_diary.two_zero_two_three.root_home.modal_drawer.TopMostDestination
 
 private val drawerHandler = ModalDrawerHandler()
@@ -27,79 +28,88 @@ fun AndroidRootNavigation(
         notSignedIn = false
         navHostController.popBackStack()
     }
-    val pop:()->Unit={
+    LaunchedEffect(Unit) {
+        navHostController.currentBackStackEntryFlow.collect {
+            val peekRoute = it.destination.route
+            if (peekRoute == OtherFeatureNavGraph.HOME_ROUTE) {
+                //may be for back press,currently in the home,but the drawer item may be
+                //selected has not changed to home,that is why manually chaining selection item
+                //try to implement a better solution later
+                handler.onSectionSelected(0)
+            }
+        }
+    }
+    val pop: () -> Unit = {
         navHostController.popBackStack()
     }
     val onLogOutRequest: () -> Unit = {
         navHostController.navigate(GraphRoutes.AUTH)
         notSignedIn = true
     }
-    if (notSignedIn)
-        navHostController.navigate(GraphRoutes.AUTH)
-    else {
-        RootModuleDrawer(
-            onLogOutRequest = onLogOutRequest,
-            drawerHandler = handler,
-            onEvent = { destination ->
-                when (destination) {
-                    TopMostDestination.Home -> {
-                        OtherFeatureNavGraph.navigateToHome(navHostController)
-                    }
+    // if (notSignedIn)
+    //  navHostController.navigate(GraphRoutes.AUTH)
 
-                    TopMostDestination.MessageFromVC -> {
-                        OtherFeatureNavGraph.navigateToMessageFromVC(navHostController)
-                    }
-
-                    TopMostDestination.AboutUs -> {
-                        OtherFeatureNavGraph.navigateToAboutUs(navHostController)
-                    }
-
-                    TopMostDestination.EventGallery -> {
-                        OtherFeatureNavGraph.navigateToEventGallery(navHostController)
-                    }
-
-                    TopMostDestination.FacultyList -> {
-                        navigateAsTopMostDestination(GraphRoutes.FACULTY_FEATURE,navHostController)
-                       // navHostController.navigate()
-                    }
-
-                    TopMostDestination.AdminOffice -> {
-                        navigateAsTopMostDestination(GraphRoutes.ADMIN_OFFICE_FEATURE,navHostController)
-                      //  navHostController.navigate(GraphRoutes.ADMIN_OFFICE_FEATURE)
-                    }
-
-                    TopMostDestination.Search -> {
-                        navigateAsTopMostDestination(GraphRoutes.SEARCH,navHostController)
-                       // navHostController.navigate(GraphRoutes.SEARCH)
-                    }
-
-                    TopMostDestination.NoteList -> {
-                        navigateAsTopMostDestination(GraphRoutes.NOTES_FEATURE,navHostController)
-                        //navHostController.navigate(GraphRoutes.NOTES_FEATURE)
-                    }
-
-                    TopMostDestination.ExploreJust -> {
-                        onEvent(AppEvent.WebVisitRequest("https://just.edu.bd/"))
-                    }
-
-                    else -> {}
+    RootModuleDrawerAnimationLess(
+        onLogOutRequest = onLogOutRequest,
+        drawerHandler = handler,
+        onEvent = { destination ->
+            when (destination) {
+                TopMostDestination.Home -> {
+                    OtherFeatureNavGraph.navigateToHome(navHostController)
                 }
-            },
-            navHost = {
-                RootNavGraph(
-                    onEvent = onEvent,
-                    openDrawerRequest = handler::openDrawer,
-                    navController = navHostController,
-                    onLoginSuccess = onLoginSuccess,
-                    onBackPressed = pop
-                )
-            }
-        )
 
-    }
+                TopMostDestination.MessageFromVC -> {
+                    OtherFeatureNavGraph.navigateToMessageFromVC(navHostController)
+                }
+
+                TopMostDestination.AboutUs -> {
+                    OtherFeatureNavGraph.navigateToAboutUs(navHostController)
+                }
+
+                TopMostDestination.EventGallery -> {
+                    OtherFeatureNavGraph.navigateToEventGallery(navHostController)
+                }
+
+                TopMostDestination.FacultyList -> {
+                    navigateAsTopMostDestination(GraphRoutes.FACULTY_FEATURE, navHostController)
+                }
+
+                TopMostDestination.AdminOffice -> {
+                    navigateAsTopMostDestination(
+                        GraphRoutes.ADMIN_OFFICE_FEATURE,
+                        navHostController
+                    )
+                }
+
+                TopMostDestination.Search -> {
+                    navigateAsTopMostDestination(GraphRoutes.SEARCH, navHostController)
+                }
+
+                TopMostDestination.NoteList -> {
+                    navigateAsTopMostDestination(GraphRoutes.NOTES_FEATURE, navHostController)
+                }
+
+                TopMostDestination.ExploreJust -> {
+                    onEvent(AppEvent.WebVisitRequest("https://just.edu.bd/"))
+                }
+
+                else -> {}
+            }
+        },
+        navHost = {
+            RootNavGraph(
+                onEvent = onEvent,
+                openDrawerRequest = handler::openDrawer,
+                navController = navHostController,
+                onLoginSuccess = onLoginSuccess,
+                onBackPressed = pop
+            )
+        }
+    )
 
 
 }
+
 private fun navigateAsTopMostDestination(
     destination: String,
     navController: NavHostController

--- a/features/navigation/src/androidMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/root_home/navigation/RootNavGraph.kt
+++ b/features/navigation/src/androidMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/root_home/navigation/RootNavGraph.kt
@@ -26,11 +26,6 @@ fun RootNavGraph(
     onLoginSuccess: (String, String) -> Unit,
     navController: NavHostController,
 ) {
-    LaunchedEffect(Unit) {
-        navController.currentBackStack.collect {
-            println("RootNavGraph:Stack: ${it.map { it.destination.route }}")
-        }
-    }
 
     NavHost(
         modifier = modifier,

--- a/features/navigation/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/root_home/modal_drawer/NavigationItems.kt
+++ b/features/navigation/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/root_home/modal_drawer/NavigationItems.kt
@@ -14,59 +14,60 @@ import androidx.compose.material.icons.outlined.Message
 import androidx.compose.material.icons.outlined.Notes
 import androidx.compose.material.icons.outlined.School
 import androidx.compose.material.icons.outlined.Search
+import com.just.cse.digital_diary.two_zero_two_three.common_ui.custom_navigation_item.DrawerNavigationItem
 import com.just.cse.digital_diary.two_zero_two_three.common_ui.custom_navigation_item.NavigationItemInfo
 
 internal val rootModuleTopMostDestinations = listOf(
-    NavigationItemInfo(
+    DrawerNavigationItem(
         label = "Home",
         unFocusedIcon = Icons.Outlined.Home,
-        key = ""
+
     ),
 
-    NavigationItemInfo(
+    DrawerNavigationItem(
         label = "Faculty List",
         unFocusedIcon = Icons.Outlined.School,
-        key = ""
+
     ),
-    NavigationItemInfo(
+    DrawerNavigationItem(
         label = "Admin Offices",
         unFocusedIcon = Icons.Outlined.AdminPanelSettings,
-        key = ""
+
     ),
 
-    NavigationItemInfo(
+    DrawerNavigationItem(
         label = "Message(Vice -Chancellor)",
         unFocusedIcon = Icons.Outlined.Message,
-        key = ""
+
     ),
-    NavigationItemInfo(
+    DrawerNavigationItem(
         label = "About Us",
         unFocusedIcon = Icons.Outlined.Info,
-        key = ""
+
     ),
-    NavigationItemInfo(
+    DrawerNavigationItem(
         label = "Search",
         unFocusedIcon = Icons.Outlined.Search,
         focusedIcon = Icons.Filled.Search,
-        key = ""
+
     ),
-    NavigationItemInfo(
+    DrawerNavigationItem(
         label = "Notes",
         unFocusedIcon = Icons.Outlined.Notes,
         focusedIcon = Icons.Filled.Notes,
-        key = ""
+
     ),
-    NavigationItemInfo(
+    DrawerNavigationItem(
         label = "Event Gallery",
         unFocusedIcon = Icons.Outlined.Image,
         focusedIcon = Icons.Filled.Image,
-        key = ""
+
     ),
-    NavigationItemInfo(
+    DrawerNavigationItem(
         label = "Explore JUST",
         unFocusedIcon = Icons.Outlined.Explore,
         focusedIcon = Icons.Filled.Explore,
-        key = ""
+
     ),
 )
 

--- a/features/navigation/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/root_home/modal_drawer/RootModuleDrawer.kt
+++ b/features/navigation/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/root_home/modal_drawer/RootModuleDrawer.kt
@@ -11,13 +11,70 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import com.just.cse.digital_diary.two_zero_two_three.common_ui.navigation.modal_drawer.ModalDrawerDecorator
+import com.just.cse.digital_diary.two_zero_two_three.common_ui.navigation.modal_drawer.ModalDrawerDecoratorAnimationLess
 
+/**
+ * * Animation less
+ * * useful when you use navigation component to switch betweeen destinatin
+
+ */
+@Composable
+fun RootModuleDrawerAnimationLess(
+    modifier: Modifier = Modifier,
+    drawerHandler: ModalDrawerHandler,
+    onEvent: (TopMostDestination) -> Unit,
+    onLogOutRequest: () -> Unit = {},
+    navHost: @Composable () -> Unit
+) {
+
+    LaunchedEffect(Unit) {
+        drawerHandler.selectedSectionIndex.collect { destination ->
+            when (destination) {
+                RootDestinations.HOME -> onEvent(TopMostDestination.Home)
+                RootDestinations.FACULTY_LIST -> onEvent(TopMostDestination.FacultyList)
+                RootDestinations.ADMIN_OFFICE -> onEvent(TopMostDestination.AdminOffice)
+                RootDestinations.MESSAGE_FROM_VC -> onEvent(TopMostDestination.MessageFromVC)
+                RootDestinations.ABOUT_US -> onEvent(TopMostDestination.AboutUs)
+                RootDestinations.Search -> onEvent(TopMostDestination.Search)
+                RootDestinations.NOTE_LIST -> onEvent(TopMostDestination.NoteList)
+                RootDestinations.EventGallery -> onEvent(TopMostDestination.EventGallery)
+                RootDestinations.EXPLORE_JUST -> onEvent(TopMostDestination.ExploreJust)
+            }
+
+        }
+    }
+    ModalDrawerDecoratorAnimationLess(
+        modifier = modifier,
+        destinations = rootModuleTopMostDestinations,
+        selectedDesertionIndex = drawerHandler.selectedSectionIndex.collectAsState().value,
+        drawerState = drawerHandler.drawerState.collectAsState().value,
+        onDestinationSelected = drawerHandler::onSectionSelected,
+        header = {
+            Header(
+                name = "",
+                department = "",
+                onLogOutRequest = onLogOutRequest,
+            )
+
+        }
+    ) {
+        navHost()
+
+    }
+}
+
+
+/**
+ * * Has Animation
+ * * useful when you use want to navigation direcly replacing composable instead of navigation component
+
+ */
 @Composable
 fun RootModuleDrawer(
-    modifier: Modifier=Modifier,
+    modifier: Modifier = Modifier,
     drawerHandler: ModalDrawerHandler,
-    onEvent:(TopMostDestination)->Unit,
-    onLogOutRequest:()->Unit={},
+    onEvent: (TopMostDestination) -> Unit,
+    onLogOutRequest: () -> Unit = {},
     navHost: @Composable() (AnimatedContentScope.(Int) -> Unit)
 ) {
 
@@ -30,15 +87,20 @@ fun RootModuleDrawer(
                 RootDestinations.ADMIN_OFFICE -> onEvent(TopMostDestination.AdminOffice)
                 RootDestinations.MESSAGE_FROM_VC -> onEvent(TopMostDestination.MessageFromVC)
                 RootDestinations.ABOUT_US -> onEvent(TopMostDestination.AboutUs)
-                RootDestinations.Search ->onEvent(TopMostDestination.Search)
+                RootDestinations.Search -> onEvent(TopMostDestination.Search)
                 RootDestinations.NOTE_LIST -> onEvent(TopMostDestination.NoteList)
-                RootDestinations.EventGallery ->onEvent(TopMostDestination.EventGallery)
+                RootDestinations.EventGallery -> onEvent(TopMostDestination.EventGallery)
                 RootDestinations.EXPLORE_JUST -> onEvent(TopMostDestination.ExploreJust)
             }
+
         }
     }
     ModalDrawerDecorator(
-        modifier=modifier,
+        modifier = modifier,
+        destinations = rootModuleTopMostDestinations,
+        selectedDesertionIndex = drawerHandler.selectedSectionIndex.collectAsState().value,
+        drawerState = drawerHandler.drawerState.collectAsState().value,
+        onDestinationSelected = drawerHandler::onSectionSelected,
         header = {
             Header(
                 name = "",
@@ -46,31 +108,25 @@ fun RootModuleDrawer(
                 onLogOutRequest = onLogOutRequest,
             )
 
-        },
-        visibilityDelay = 10,
-        drawerState = drawerHandler.drawerState.collectAsState().value,
-        destinations = rootModuleTopMostDestinations,
-        selectedDesertionIndex = drawerHandler.selectedSectionIndex.collectAsState().value,
-        onDestinationSelected = drawerHandler::onSectionSelected,
-        content = {
-            AnimatedContent(
-                modifier = Modifier,
-                targetState = drawerHandler.selectedSectionIndex.collectAsState().value,
-                transitionSpec = {
-                    slideIntoContainer(
-                        animationSpec = tween(durationMillis = 300, easing = EaseIn),
-                        towards = AnimatedContentTransitionScope.SlideDirection.Up
-                    ).togetherWith(
-                        slideOutOfContainer(
-                            animationSpec = tween(durationMillis = 300, easing = EaseIn),
-                            towards = AnimatedContentTransitionScope.SlideDirection.Down
-                        )
-                    )
-                }
-            ) { localDestination ->
-                navHost(localDestination)
-            }
-
         }
-    )
+    ) {
+        AnimatedContent(
+            modifier = Modifier,
+            targetState = drawerHandler.selectedSectionIndex.collectAsState().value,
+            transitionSpec = {
+                slideIntoContainer(
+                    animationSpec = tween(durationMillis = 100, easing = EaseIn),
+                    towards = AnimatedContentTransitionScope.SlideDirection.Up
+                ).togetherWith(
+                    slideOutOfContainer(
+                        animationSpec = tween(durationMillis = 100, easing = EaseIn),
+                        towards = AnimatedContentTransitionScope.SlideDirection.Down
+                    )
+                )
+            }
+        ) { localDestination ->
+            navHost(localDestination)
+        }
+
+    }
 }

--- a/features/others/navgraph/src/androidMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/features/others/destination/graph/OtherFeatureNavGraph.kt
+++ b/features/others/navgraph/src/androidMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/features/others/destination/graph/OtherFeatureNavGraph.kt
@@ -22,35 +22,37 @@ import kotlinx.coroutines.flow.update
 
 object OtherFeatureNavGraph {
     const val ROUTE = "OtherFeatureNavigation"
-    private const val HOME_SCREEN = "Home"
+    const val HOME_ROUTE = "Home"
     private const val ABOUT_US_SCREEN = "AboutUs"
     private const val EVENT_GALLERY_SCREEN = "EventGallery"
     private const val MESSAGE_FROM_VC_SCREEN = "MessageFromVC"
     private val showNavigationIcon = MutableStateFlow(true)
+
     /**
     Useful for nav rail
      */
     fun enableBackNavigation() {
         showNavigationIcon.update { true }
     }
-    fun disableBackNavigation(){
+
+    fun disableBackNavigation() {
         showNavigationIcon.update { false }
     }
 
     fun navigateToHome(navController: NavHostController) {
-        navigateAsTopMostDestination(HOME_SCREEN,navController)
+        navigateAsTopMostDestination(HOME_ROUTE, navController)
     }
 
     fun navigateToAboutUs(navController: NavHostController) {
-        navigateAsTopMostDestination(ABOUT_US_SCREEN,navController)
+        navigateAsTopMostDestination(ABOUT_US_SCREEN, navController)
     }
 
     fun navigateToEventGallery(navController: NavHostController) {
-        navigateAsTopMostDestination(EVENT_GALLERY_SCREEN,navController)
+        navigateAsTopMostDestination(EVENT_GALLERY_SCREEN, navController)
     }
 
     fun navigateToMessageFromVC(navController: NavHostController) {
-        navigateAsTopMostDestination(MESSAGE_FROM_VC_SCREEN,navController)
+        navigateAsTopMostDestination(MESSAGE_FROM_VC_SCREEN, navController)
     }
 
     private fun navigateAsTopMostDestination(
@@ -70,9 +72,9 @@ object OtherFeatureNavGraph {
         with(navGraphBuilder) {
             navigation(
                 route = ROUTE,
-                startDestination = HOME_SCREEN
+                startDestination = HOME_ROUTE
             ) {
-                composable(route = HOME_SCREEN) {
+                composable(route = HOME_ROUTE) {
                     TopBarDecorator(
                         enableNavigation = showNavigationIcon.collectAsState().value,
                         onExitRequest = onExitRequest,

--- a/layers/ui/common_ui/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/common_ui/custom_navigation_item/NavigationItemInfo.kt
+++ b/layers/ui/common_ui/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/common_ui/custom_navigation_item/NavigationItemInfo.kt
@@ -10,6 +10,12 @@ data class NavigationGroup(
 )
 
 //use key to uniquely identify
+data class DrawerNavigationItem(
+    val label: String,
+    val unFocusedIcon: ImageVector,
+    val focusedIcon: ImageVector =unFocusedIcon,
+    val badge: String? = null,
+)
 data class NavigationItemInfo<T>(
     val key:T,
     val label: String,

--- a/layers/ui/common_ui/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/common_ui/navigation/modal_drawer/DrawerDecorator.kt
+++ b/layers/ui/common_ui/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/common_ui/navigation/modal_drawer/DrawerDecorator.kt
@@ -4,50 +4,49 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import com.just.cse.digital_diary.two_zero_two_three.common_ui.custom_navigation_item.DrawerNavigationItem
 import com.just.cse.digital_diary.two_zero_two_three.common_ui.custom_navigation_item.NavigationItemInfo
 import com.just.cse.digital_diary.two_zero_two_three.common_ui.navigation.modal_drawer.sheet.Sheet
 
-@Composable
-fun <T>ModalDrawerDecorator(
-    drawerState: ModalDrawerState,
-    visibilityDelay:Long = 70L,
-    destinations: List<NavigationItemInfo<T>>,
-    selectedDesertionIndex: Int,
-    onDestinationSelected: (Int) -> Unit = {},
-    header: @Composable () -> Unit,
-    content: @Composable () -> Unit,
-) {
-    ModalDrawer(
-        modifier = Modifier,
-        drawerState = drawerState.drawerState.collectAsState().value,
-        sheet = {
-            Sheet(
-                visibilityDelay = visibilityDelay,
-                selectedDestinationIndex = selectedDesertionIndex,
-                destinations = destinations,
-                onDestinationSelected = { index ->
-                    onDestinationSelected(index)
-                    drawerState.closeDrawer()
-                },
-                header = header
-            )
-        },
-        content=content
-    )
-}
+//@Composable
+//fun <T>ModalDrawerDecorator(
+//    drawerState: ModalDrawerState,
+//    visibilityDelay:Long = 0L,
+//    destinations: List<NavigationItemInfo<T>>,
+//    selectedDesertionIndex: Int,
+//    onDestinationSelected: (Int) -> Unit = {},
+//    header: @Composable () -> Unit,
+//    content: @Composable () -> Unit,
+//) {
+//    ModalDrawer(
+//        modifier = Modifier,
+//        drawerState = drawerState.drawerState.collectAsState().value,
+//        sheet = {
+//            Sheet(
+//                selectedDestinationIndex = selectedDesertionIndex,
+//                header = header,
+//                destinations = destinations
+//            ) { index ->
+//                onDestinationSelected(index)
+//                drawerState.closeDrawer()
+//            }
+//        },
+//        content=content
+//    )
+//}
 
-
+/**
+ * * Sheet appears has no animation
+ */
 @Composable
-fun <T>ModalDrawerDecorator(
-    modifier: Modifier=Modifier,
-    destinations: List<NavigationItemInfo<T>>,
-    visibilityDelay:Long = 0L,
+fun ModalDrawerDecoratorAnimationLess(
+    modifier: Modifier = Modifier,
+    destinations: List<DrawerNavigationItem>,
     selectedDesertionIndex: Int,
     drawerState: DrawerState,
     onDestinationSelected: (Int) -> Unit = {},
-    header:@Composable ()->Unit,
+    header: @Composable () -> Unit,
     content: @Composable () -> Unit,
 ) {
 
@@ -55,22 +54,48 @@ fun <T>ModalDrawerDecorator(
         modifier = modifier,
         drawerState = drawerState,
         sheet = {
-           AnimatedVisibility(
-               visible =drawerState.currentValue==DrawerValue.Open,
-           ){
-               Sheet(
-                   visibilityDelay=visibilityDelay,
-                   selectedDestinationIndex = selectedDesertionIndex,
-                   destinations = destinations,
-                   onDestinationSelected = { index ->
-                       onDestinationSelected(index)
-                   },
-                   header = header
-               )
-           }
+            Sheet(
+                selectedDestinationIndex = selectedDesertionIndex,
+                header = header,
+                destinations = destinations
+            ) { index ->
+                onDestinationSelected(index)
+            }
+        },
+        content = content
+    )
+}
+
+
+@Composable
+fun ModalDrawerDecorator(
+    modifier: Modifier = Modifier,
+    destinations: List<DrawerNavigationItem>,
+    selectedDesertionIndex: Int,
+    drawerState: DrawerState,
+    onDestinationSelected: (Int) -> Unit = {},
+    header: @Composable () -> Unit,
+    content: @Composable () -> Unit,
+) {
+
+    ModalDrawer(
+        modifier = modifier,
+        drawerState = drawerState,
+        sheet = {
+            AnimatedVisibility(
+                visible = drawerState.currentValue == DrawerValue.Open,
+            ) {
+                Sheet(
+                    selectedDestinationIndex = selectedDesertionIndex,
+                    header = header,
+                    destinations = destinations
+                ) { index ->
+                    onDestinationSelected(index)
+                }
+            }
 
         },
-        content=content
+        content = content
     )
 }
 

--- a/layers/ui/common_ui/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/common_ui/navigation/modal_drawer/sheet/Sheet.kt
+++ b/layers/ui/common_ui/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/common_ui/navigation/modal_drawer/sheet/Sheet.kt
@@ -8,16 +8,16 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.just.cse.digital_diary.two_zero_two_three.common_ui.custom_navigation_item.DrawerNavigationItem
 import com.just.cse.digital_diary.two_zero_two_three.common_ui.custom_navigation_item.NavigationGroup
 import com.just.cse.digital_diary.two_zero_two_three.common_ui.custom_navigation_item.NavigationItemInfo
 import com.just.cse.digital_diary.two_zero_two_three.common_ui.navigation.modal_drawer.NavGroupSelectedItem
 
 @Composable
-fun <T> Sheet(
+fun Sheet(
     selectedDestinationIndex: Int = -1,
-    visibilityDelay: Long,
     header: @Composable () -> Unit,
-    destinations: List<NavigationItemInfo<T>>,
+    destinations: List<DrawerNavigationItem>,
     onDestinationSelected: (index: Int) -> Unit,
 ) {
 
@@ -27,9 +27,8 @@ fun <T> Sheet(
         destinations = destinations,
         destinationDecorator = { index ->
             val navigationItem = destinations[index]
-            ItemDecorator(
-                visibilityDelay = index * visibilityDelay,
-                navigationItem = navigationItem,
+            DrawerItemDecorator(
+                item = navigationItem,
                 isSelected = index == selectedDestinationIndex,
                 onClick = {
                     onDestinationSelected(index)
@@ -91,10 +90,10 @@ fun Sheet(
 }
 
 @Composable
-fun <T> DrawerSheet(
+fun DrawerSheet(
     header: (@Composable () -> Unit)? = null,
     footer: (@Composable () -> Unit)? = null,
-    destinations: List<NavigationItemInfo<T>>,
+    destinations: List<DrawerNavigationItem>,
     destinationDecorator: @Composable (index: Int) -> Unit,
 ) {
     ModalDrawerSheet(

--- a/layers/ui/common_ui/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/common_ui/navigation/modal_drawer/sheet/SheetItemDecorator.kt
+++ b/layers/ui/common_ui/src/commonMain/kotlin/com/just/cse/digital_diary/two_zero_two_three/common_ui/navigation/modal_drawer/sheet/SheetItemDecorator.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.just.cse.digital_diary.two_zero_two_three.common_ui.custom_navigation_item.DrawerNavigationItem
 import com.just.cse.digital_diary.two_zero_two_three.common_ui.custom_navigation_item.NavigationItemInfo
 import kotlinx.coroutines.delay
 
@@ -56,6 +57,33 @@ fun <T> ItemDecorator(
         )
     }
 
+
+}
+
+@Composable
+fun  DrawerItemDecorator(
+    item: DrawerNavigationItem,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    NavigationDrawerItem(
+        modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
+        icon = {
+            Icon(
+                item.unFocusedIcon,
+                contentDescription = null
+            )
+        },
+        label = {
+            Text(
+                text = item.label,
+
+
+                )
+        },
+        selected = isSelected,
+        onClick = onClick,
+    )
 
 }
 


### PR DESCRIPTION
- The drawer animation was janky due to the following reasons:

  - ModalDrawerDecorator utilized animation when switching its content.
  - Android Navigation NavHost also employed animation, contributing to the janky behavior.

  - The issue was addressed by:
    - Eliminating animation in ModalDrawerDecorator.
    - Removing animation for each drawer item.

- The drawer item selection was not synchronized:
  
  - Specifically when the user navigated back to the home screen by pressing the back button.In this scenario, the DrawerHandler was not notified of the change in the current destination.
   - The issue was resolved:
      - By observing the peek destination. If the peek destination is HomeRoute, the current selected item in the drawer is explicitly updated.

I encountered difficulty in resolving the issue regarding` the need for occasional multiple taps to open a topmost destination.`
At the moment, I don't have a more effective solution, but I plan to refactor the code when I come up with one.
To eliminate the janky animation, ensure that a complex object is not created with each frame of the animation.

